### PR TITLE
Remove masks div 255 in save_images

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,7 +118,7 @@ class Occlusion_Generator:
         print(self.args["outputImgDir"])
         
         cv2.imwrite(os.path.join(self.args["outputImgDir"], f"{img_name}.jpg"),image)
-        cv2.imwrite(os.path.join(self.args["outputMaskDir"], f"{img_name}.png"),mask/255)
+        cv2.imwrite(os.path.join(self.args["outputMaskDir"], f"{img_name}.png"),mask)
         if self.args["maskForOcclusion"]:
             cv2.imwrite(os.path.join(self.args["occlusionMaskDir"], f"{img_name}.png"),occlusion_mask)
 


### PR DESCRIPTION
Hi there, I found that the output masks are divided by 255, this will cause all output masks to scale to 0~1 and make the masks in Google Drive / RealOcc-Wild and RealOcc black images.

I am just wondering if this is what you expected. This could be misinterpreted as corrupted images. Because all other datasets with masks (11k-Hands, CelebAMask-HQ...) store their mask images in 0~255 format.